### PR TITLE
Additional details in selects

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -56,9 +56,7 @@
             { "blankLine": "never", "prev": "block-like", "next": "default" }
         ],
         "no-unused-vars": "off",
-        "@typescript-eslint/no-unused-vars": ["error", {
-            "varsIgnorePattern": "NodeCGBrowser"
-        }],
+        "@typescript-eslint/no-unused-vars": "error",
         "no-empty": ["error", { "allowEmptyCatch":  true }],
         "@typescript-eslint/ban-ts-comment": ["error", {
             "ts-ignore": "allow-with-description"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.10.0
+
+- ipl-select emits the full option object on update as an additional parameter
+
 # 2.9.2
 
 - Revert changes to ipl-button

--- a/examples/Examples.vue
+++ b/examples/Examples.vue
@@ -28,6 +28,8 @@
         <progress-bar-example />
         <h2 id="spinner-example">ipl-spinner</h2>
         <spinner-example />
+        <h2 id="select-example">ipl-select</h2>
+        <select-example />
     </div>
 </template>
 
@@ -47,9 +49,11 @@ import UploadExample from './components/UploadExample.vue';
 import InputExample from './components/InputExample.vue';
 import ProgressBarExample from './components/ProgressBarExample.vue';
 import SpinnerExample from './components/SpinnerExample.vue';
+import SelectExample from './components/SelectExample.vue';
 
 export default defineComponent({
     components: {
+        SelectExample,
         SpinnerExample,
         ProgressBarExample,
         InputExample,

--- a/examples/components/SelectExample.vue
+++ b/examples/components/SelectExample.vue
@@ -1,0 +1,72 @@
+<template>
+    <ipl-space>
+        selected value: {{ selectValue }}
+        <br>
+        details: {{ additionalOptionDetails }}
+        <ipl-select
+            v-model="selectValue"
+            :options="options"
+            label="Select"
+            @update:model-value="onValueChange"
+        />
+        <h3>Option groups</h3>
+        selected value: {{ groupedSelectValue }}
+        <br>
+        details: {{ groupedSelectDetails }}
+        <ipl-select
+            v-model="groupedSelectValue"
+            :option-groups="optionGroups"
+            label="Select w/ option groups"
+            @update:model-value="onGroupedValueChange"
+        />
+        <br>
+        <ipl-select
+            model-value="opt1"
+            :options="[{ name: 'Option One', value: 'opt1' }]"
+            disabled
+            label="Disabled"
+        />
+    </ipl-space>
+</template>
+
+<script setup lang="ts">
+import { IplSelect, IplSpace } from '../../src';
+import { ref } from 'vue';
+
+const selectValue = ref<string | null>(null);
+const additionalOptionDetails = ref<Record<string, unknown> | null>(null);
+
+function onValueChange(newValue: string, details: Record<string, unknown>) {
+    additionalOptionDetails.value = details;
+}
+
+const options = [
+    { name: 'option one', value: 'opt1' },
+    { name: 'option two', value: 'opt2', additionalDetails: 'test test?' },
+    { name: 'option three', value: 'opt3' }
+];
+
+const groupedSelectValue = ref<string | null>(null);
+const groupedSelectDetails = ref<Record<string, unknown> | null>(null);
+
+function onGroupedValueChange(newValue: string, details: Record<string, unknown>) {
+    groupedSelectDetails.value = details;
+}
+
+const optionGroups = [
+    {
+        name: 'first group!',
+        options: [
+            { name: 'option one', value: 'opt1' },
+            { name: 'option two', value: 'opt2', additionalDetails: 'test test?' },
+            { name: 'option three', value: 'opt3' }
+        ]
+    },{
+        name: 'second group!',
+        options: [
+            { name: 'option four', value: 'opt4' },
+            { name: 'option five', value: 'opt5' },
+        ]
+    }
+];
+</script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@iplsplatoon/vue-components",
-    "version": "2.9.2",
+    "version": "2.10.0",
     "description": "Vue components for internal Inkling Performance Labs utilities.",
     "homepage": "https://github.com/IPLSplatoon/vue-components",
     "repository": "https://github.com/IPLSplatoon/vue-components",

--- a/src/components/__tests__/iplSelect.test.ts
+++ b/src/components/__tests__/iplSelect.test.ts
@@ -67,9 +67,10 @@ describe('IplSelect', () => {
     it('emits update message on change', async () => {
         const wrapper = mount(IplSelect, {
             props: {
-                modelValue: '', options: [
+                modelValue: '',
+                options: [
                     { name: 'Option', value: 'opt' },
-                    { name: 'Option the Second', value: 'opt2' },
+                    { name: 'Option the Second', value: 'opt2', testAdditionalAttribute: true },
                     { name: 'Opt 3', value: 'optthree' }
                 ]
             }
@@ -79,6 +80,38 @@ describe('IplSelect', () => {
 
         const emitted = wrapper.emitted('update:modelValue');
         expect(emitted?.length).toEqual(1);
-        expect(emitted?.[0]).toEqual([ 'opt2' ]);
+        expect(emitted?.[0]).toEqual([ 'opt2', { name: 'Option the Second', value: 'opt2', testAdditionalAttribute: true } ]);
+    });
+
+    it('emits update message on change for a grouped select', async () => {
+        const wrapper = mount(IplSelect, {
+            props: {
+                modelValue: '',
+                optionGroups: [
+                    {
+                        name: 'Group A',
+                        options: [
+                            { name: 'Option', value: 'opt' },
+                            { name: 'Option the Second', value: 'opt2', disabled: false },
+                            { name: 'Opt 3', value: 'optthree' }
+                        ]
+                    },
+                    {
+                        name: 'Group B',
+                        options: [
+                            { name: 'Another Option', value: 'opt4', testAdditionalAttribute: 999 },
+                            { name: 'Option the Fifth', value: 'opt5' },
+                            { name: 'Opt 6', value: 'opt6', disabled: true }
+                        ]
+                    }
+                ]
+            }
+        });
+
+        await wrapper.get('select').setValue('opt4');
+
+        const emitted = wrapper.emitted('update:modelValue');
+        expect(emitted?.length).toEqual(1);
+        expect(emitted?.[0]).toEqual([ 'opt4', { name: 'Another Option', value: 'opt4', testAdditionalAttribute: 999 } ]);
     });
 });

--- a/src/types/select.ts
+++ b/src/types/select.ts
@@ -1,4 +1,4 @@
-export type Option = { name: string, value: string, disabled?: boolean };
+export type Option = { name: string, value: string, disabled?: boolean, [key: string]: unknown };
 
 export type SelectOptions = Option[];
 


### PR DESCRIPTION
When selecting a value with ipl-select, the event that is emitted contains, alongside the usual `value`, the entire option object that was originally passed in through props. This allows for adding additional data to options besides just a string-only value.